### PR TITLE
Add warnings when WebAssembly is unavailable (Chrome iOS Lockdown Mode)

### DIFF
--- a/src/components/convo-explorer/App.tsx
+++ b/src/components/convo-explorer/App.tsx
@@ -9,6 +9,7 @@ import { FloatingModal } from "./FloatingModal";
 import { INITIAL_ACTION, PALETTE_COLORS, VOTE_COLORS, VOTE_COLORS_HIGHLIGHT_PASS, UNPAINTED_VALUE, DISPLAY_MASK_COLUMN } from "@/constants";
 import { getVotesForParticipants, getVoteCountsForAllParticipants, getNonModeratedStatementIds, initializeDuckDB, loadVotesFromMemory } from "../../lib/duckdb";
 import { resolveAssetPath } from "../../lib/paths";
+import { isWebAssemblySupported } from "../../lib/wasm-detect";
 import { Spinner } from "../ui/spinner";
 import {
   calculateRepresentativeStatements,
@@ -779,6 +780,8 @@ export const App: React.FC<AppProps> = ({ testAnimation = false, kedroBaseUrl, i
     return false; // Default: allow other behaviors
   }
 
+  const wasmSupported = isWebAssemblySupported();
+
   if (loading) {
     return (
       <div className="relative h-screen w-screen flex items-center justify-center touch-none select-none">
@@ -800,6 +803,13 @@ export const App: React.FC<AppProps> = ({ testAnimation = false, kedroBaseUrl, i
       translate="no"
       data-notranslate="true"
     >
+      {/* WebAssembly unavailable warning */}
+      {!wasmSupported && (
+        <div className="absolute top-0 left-0 right-0 z-50 bg-amber-100 border-b border-amber-300 px-4 py-2 text-center text-sm text-amber-900">
+          Some features are unavailable because WebAssembly is disabled in this browser.
+          This can happen when Lockdown Mode is enabled (check both browser and device security settings).
+        </div>
+      )}
       {/* D3Map: absolutely positioned to fill parent */}
       <div className="absolute inset-0 z-0">
         <div

--- a/src/components/showcase-lander/App.tsx
+++ b/src/components/showcase-lander/App.tsx
@@ -3,6 +3,7 @@ import HomePage from './HomePage';
 import ParameterExplorerApp from '@/components/param-explorer/ParameterExplorerApp';
 import { App as PerspectiveMapApp } from '@/components/convo-explorer/App';
 import type { PreloadedData } from '@/components/convo-explorer/App';
+import { isWebAssemblySupported } from '@/lib/wasm-detect';
 
 type CurrentPage = 'home' | 'parameter-explorer' | 'perspective-explorer';
 
@@ -42,6 +43,14 @@ const App: React.FC = () => {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleLoadFile = useCallback(() => {
+    if (!isWebAssemblySupported()) {
+      alert(
+        'Cannot load h5ad files because WebAssembly is disabled in this browser.\n\n' +
+        'This can happen when Lockdown Mode is enabled. ' +
+        'Please check both your browser and device security settings.'
+      );
+      return;
+    }
     fileInputRef.current?.click();
   }, []);
 

--- a/src/lib/wasm-detect.ts
+++ b/src/lib/wasm-detect.ts
@@ -1,0 +1,10 @@
+/**
+ * Check if WebAssembly is available in the current browser environment.
+ *
+ * WebAssembly can be disabled by browser "Lockdown Mode" settings
+ * (e.g. Chrome iOS Lockdown Mode, iOS system Lockdown Mode) or
+ * by content blockers / security extensions.
+ */
+export function isWebAssemblySupported(): boolean {
+  return typeof WebAssembly !== 'undefined';
+}


### PR DESCRIPTION
## Summary
- Detects when WebAssembly is disabled (e.g. Chrome iOS Lockdown Mode) and shows clear user-facing warnings instead of silently failing
- Adds an amber banner in the perspective explorer when WASM features are unavailable
- Shows a system alert dialog when users try to upload h5ad files without WASM support

## Context
Chrome on iOS has its own Lockdown Mode (separate from iOS system Lockdown Mode) that disables WebAssembly entirely. This caused two silent failures:
1. DuckDB-WASM initialization failed → "Database connection not available" error in statement drawer
2. h5wasm failed → h5ad file uploads silently did nothing

Root cause: `ReferenceError: Can't find variable: WebAssembly`

Safari and Edge on iOS were unaffected — only Chrome iOS with its Lockdown Mode enabled.

Closes #14

## Test plan
- [x] Verify warning banner appears when WebAssembly is unavailable
- [x] Verify alert dialog appears when clicking upload button without WASM
- [x] Verify no warnings appear in normal browsers with WASM available
- [x] Build passes, tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)