### PR TITLE
feat: add votes CSV download and date-prefix option to download modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- "Download Votes CSV" button in the download modal to export a vote matrix as `vote-matrix.csv` ([#35](https://github.com/patcon/polislike-human-cartography-prototype-v2/issues/35)). Rows are participants, columns are statement IDs, and values are `1` (agree), `-1` (disagree), `0` (pass), or empty (no vote). The modal now also shows a toggle to prefix filenames with today's date (`YYYY-MM-DD-`), and uses the `conversation_id` from the h5ad file (if present) as a filename prefix.
 - "Download Data" button in the projection selector panel to export participant metadata as `participants.csv` ([#33](https://github.com/patcon/polislike-human-cartography-prototype-v2/issues/33)). A confirmation dialog shows participant and column counts before downloading. Includes a `manual_painted` column with the color name of any painted group (e.g. `Orange`, blank if unpainted).
 - `FloatingModal` legend when viewing an obs-column annotation in the metrics layer ([#29](https://github.com/patcon/polislike-human-cartography-prototype-v2/issues/29)).
   - Shows the column name as the label and colored category swatches for categorical columns; continuous columns show an empty modal (legend to follow).

--- a/src/components/convo-explorer/App.tsx
+++ b/src/components/convo-explorer/App.tsx
@@ -5,10 +5,10 @@ import { D3Map } from "./D3Map";
 import { MapOverlay } from "./MapOverlay";
 import { ParticipantCountBar } from "./ParticipantCountBar";
 import { ClearColorsDialog } from "./ClearColorsDialog";
-import { DownloadObsCsvDialog } from "./DownloadObsCsvDialog";
+import { DownloadDialog } from "./DownloadDialog";
 import { FloatingModal } from "./FloatingModal";
 import { INITIAL_ACTION, PALETTE_COLOR_DEFINITIONS, PALETTE_COLORS, VOTE_COLORS, VOTE_COLORS_HIGHLIGHT_PASS, UNPAINTED_VALUE, DISPLAY_MASK_COLUMN } from "@/constants";
-import { getVotesForParticipants, getVoteCountsForAllParticipants, getNonModeratedStatementIds, initializeDuckDB, loadVotesFromMemory } from "../../lib/duckdb";
+import { getVotesForParticipants, getVoteCountsForAllParticipants, getNonModeratedStatementIds, initializeDuckDB, loadVotesFromMemory, getAllVotes } from "../../lib/duckdb";
 import { resolveAssetPath } from "../../lib/paths";
 import { isWebAssemblySupported } from "../../lib/wasm-detect";
 import { Spinner } from "../ui/spinner";
@@ -44,6 +44,8 @@ export type PreloadedData = {
   fullDimensionEmbeddings?: Record<string, [string, number[]][]>;
   /** Per-participant metadata columns from obs/ with type metadata */
   obsColumns?: Record<string, ObsColumnInfo>;
+  /** Optional conversation identifier from uns['conversation_id'] */
+  conversationId?: string;
 };
 
 type AppProps = {
@@ -747,8 +749,34 @@ export const App: React.FC<AppProps> = ({ testAnimation = false, kedroBaseUrl, i
     setClearDialogOpen(true);
   }, []);
 
+  // Build a download filename with optional date prefix and conversationId
+  const buildFilename = React.useCallback((base: string, ext: string, prefixDate?: boolean): string => {
+    const parts = [];
+    if (prefixDate) parts.push(new Date().toISOString().slice(0, 10));
+    if (preloadedData?.conversationId) parts.push(preloadedData.conversationId);
+    parts.push(base);
+    return parts.join('-') + '.' + ext;
+  }, [preloadedData?.conversationId]);
+
+  // Escape a CSV cell value
+  const escapeCsvCell = (cell: string): string => {
+    const s = String(cell);
+    return s.includes(',') || s.includes('"') || s.includes('\n') ? `"${s.replace(/"/g, '""')}"` : s;
+  };
+
+  // Trigger a CSV file download
+  const downloadCsv = (csvContent: string, filename: string) => {
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
   // Clear all painted colors - reset all points to unpainted
-  const handleDownloadObsCsv = React.useCallback(() => {
+  const handleDownloadObsCsv = React.useCallback((prefixDate: boolean) => {
     const obsColumns = preloadedData?.obsColumns;
     if (!obsColumns || dataset.length === 0) return;
 
@@ -765,20 +793,44 @@ export const App: React.FC<AppProps> = ({ testAnimation = false, kedroBaseUrl, i
     });
 
     const csvContent = [header, ...rows]
-      .map(row => row.map(cell => {
-        const s = String(cell);
-        return s.includes(',') || s.includes('"') || s.includes('\n') ? `"${s.replace(/"/g, '""')}"` : s;
-      }).join(','))
+      .map(row => row.map(escapeCsvCell).join(','))
       .join('\n');
 
-    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = 'participants.csv';
-    link.click();
-    URL.revokeObjectURL(url);
-  }, [dataset, pointGroups, preloadedData?.obsColumns]);
+    downloadCsv(csvContent, buildFilename('participants', 'csv', prefixDate));
+  }, [dataset, pointGroups, preloadedData?.obsColumns, buildFilename]);
+
+  // Download vote matrix CSV: rows=participants, columns=statement IDs, values=vote or empty
+  const handleDownloadVoteCsv = React.useCallback(async (prefixDate: boolean) => {
+    if (!preloadedData?.statements || dataset.length === 0) return;
+
+    const statementIds = preloadedData.statements.map(s => s.statement_id);
+    const allVoteRows = await getAllVotes(kedroBaseUrl, currentPipelineId === 'default' ? undefined : currentPipelineId);
+
+    // Build lookup: participant_id → Map<comment_id, vote>
+    const voteLookup = new Map<string, Map<string, number>>();
+    for (const row of allVoteRows) {
+      if (!voteLookup.has(row.participant_id)) {
+        voteLookup.set(row.participant_id, new Map());
+      }
+      voteLookup.get(row.participant_id)!.set(row.comment_id, row.vote);
+    }
+
+    const header = ['participant_id', ...statementIds];
+    const rows = dataset.map(([participantId]) => {
+      const participantVotes = voteLookup.get(participantId);
+      const values = statementIds.map(sid => {
+        if (!participantVotes || !participantVotes.has(sid)) return '';
+        return String(participantVotes.get(sid));
+      });
+      return [participantId, ...values];
+    });
+
+    const csvContent = [header, ...rows]
+      .map(row => row.map(escapeCsvCell).join(','))
+      .join('\n');
+
+    downloadCsv(csvContent, buildFilename('vote-matrix', 'csv', prefixDate));
+  }, [dataset, preloadedData?.statements, kedroBaseUrl, currentPipelineId, buildFilename]);
 
   const handleClearAllColors = React.useCallback(() => {
     setPointGroups(Array(dataset.length).fill(UNPAINTED_VALUE));
@@ -1020,13 +1072,16 @@ export const App: React.FC<AppProps> = ({ testAnimation = false, kedroBaseUrl, i
         onConfirm={handleClearAllColors}
       />
 
-      {/* Download Obs CSV Dialog */}
-      <DownloadObsCsvDialog
+      {/* Download Dialog */}
+      <DownloadDialog
         open={downloadObsCsvDialogOpen}
         onOpenChange={setDownloadObsCsvDialogOpen}
         onConfirm={handleDownloadObsCsv}
+        onConfirmVotes={preloadedData?.statements ? handleDownloadVoteCsv : undefined}
         participantCount={dataset.length}
         columnCount={Object.keys(preloadedData?.obsColumns ?? {}).length}
+        statementCount={preloadedData?.statements?.length}
+        conversationId={preloadedData?.conversationId}
       />
     </div>
   );

--- a/src/components/convo-explorer/DownloadDialog.tsx
+++ b/src/components/convo-explorer/DownloadDialog.tsx
@@ -13,6 +13,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+
 type DownloadDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -54,38 +55,44 @@ export const DownloadDialog = React.forwardRef<
             {' '}The files can be opened in any spreadsheet application.
           </AlertDialogDescription>
         </AlertDialogHeader>
-        <AlertDialogFooter>
-          <div className="flex items-center gap-2 mr-auto">
+
+        <div className="flex flex-col gap-3 py-1">
+          <div className="flex items-center gap-3">
             <Switch
               id="prefix-date"
               checked={prefixDate}
               onCheckedChange={setPrefixDate}
             />
             <label htmlFor="prefix-date" className="text-sm cursor-pointer">
-              Prefix with today's date
+              Prefix filenames with today's date
             </label>
           </div>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={handleConfirm}
-            className="flex items-center gap-2"
-          >
-            <FileDown size={16} />
-            Download Participants CSV
-            <span className="text-xs opacity-70">({participantCount} rows, {columnCount} cols)</span>
-          </AlertDialogAction>
-          {onConfirmVotes && (
+          <div className="flex flex-col gap-2">
             <AlertDialogAction
-              onClick={handleConfirmVotes}
-              className="flex items-center gap-2"
+              onClick={handleConfirm}
+              className="flex items-center gap-2 justify-center"
             >
               <FileDown size={16} />
-              Download Votes CSV
-              {statementCount !== undefined && (
-                <span className="text-xs opacity-70">({participantCount} rows, {statementCount} cols)</span>
-              )}
+              Download Participants CSV
+              <span className="text-xs opacity-70">({participantCount} × {columnCount})</span>
             </AlertDialogAction>
-          )}
+            {onConfirmVotes && (
+              <AlertDialogAction
+                onClick={handleConfirmVotes}
+                className="flex items-center gap-2 justify-center"
+              >
+                <FileDown size={16} />
+                Download Votes CSV
+                {statementCount !== undefined && (
+                  <span className="text-xs opacity-70">({participantCount} × {statementCount})</span>
+                )}
+              </AlertDialogAction>
+            )}
+          </div>
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/components/convo-explorer/DownloadDialog.tsx
+++ b/src/components/convo-explorer/DownloadDialog.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import * as React from "react";
+import { FileDown } from "lucide-react";
+import { Switch } from "@/components/ui/switch";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+type DownloadDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (prefixDate: boolean) => void;
+  onConfirmVotes?: (prefixDate: boolean) => void;
+  participantCount: number;
+  columnCount: number;
+  statementCount?: number;
+  conversationId?: string;
+};
+
+export const DownloadDialog = React.forwardRef<
+  React.ElementRef<typeof AlertDialogContent>,
+  DownloadDialogProps
+>(({ open, onOpenChange, onConfirm, onConfirmVotes, participantCount, columnCount, statementCount, conversationId }, ref) => {
+  const [prefixDate, setPrefixDate] = React.useState(false);
+
+  const handleConfirm = () => {
+    onConfirm(prefixDate);
+    onOpenChange(false);
+  };
+
+  const handleConfirmVotes = () => {
+    onConfirmVotes?.(prefixDate);
+    onOpenChange(false);
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent ref={ref}>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2">
+            <FileDown size={20} />
+            Download Data as CSV?
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            This will download data from the loaded file as a CSV.
+            {conversationId && <> Conversation: <strong>{conversationId}</strong>.</>}
+            {' '}The files can be opened in any spreadsheet application.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <div className="flex items-center gap-2 mr-auto">
+            <Switch
+              id="prefix-date"
+              checked={prefixDate}
+              onCheckedChange={setPrefixDate}
+            />
+            <label htmlFor="prefix-date" className="text-sm cursor-pointer">
+              Prefix with today's date
+            </label>
+          </div>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirm}
+            className="flex items-center gap-2"
+          >
+            <FileDown size={16} />
+            Download Participants CSV
+            <span className="text-xs opacity-70">({participantCount} rows, {columnCount} cols)</span>
+          </AlertDialogAction>
+          {onConfirmVotes && (
+            <AlertDialogAction
+              onClick={handleConfirmVotes}
+              className="flex items-center gap-2"
+            >
+              <FileDown size={16} />
+              Download Votes CSV
+              {statementCount !== undefined && (
+                <span className="text-xs opacity-70">({participantCount} rows, {statementCount} cols)</span>
+              )}
+            </AlertDialogAction>
+          )}
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+});
+
+DownloadDialog.displayName = "DownloadDialog";

--- a/src/components/convo-explorer/DownloadDialog.tsx
+++ b/src/components/convo-explorer/DownloadDialog.tsx
@@ -3,9 +3,9 @@
 import * as React from "react";
 import { FileDown } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -30,16 +30,6 @@ export const DownloadDialog = React.forwardRef<
   DownloadDialogProps
 >(({ open, onOpenChange, onConfirm, onConfirmVotes, participantCount, columnCount, statementCount, conversationId }, ref) => {
   const [prefixDate, setPrefixDate] = React.useState(false);
-
-  const handleConfirm = () => {
-    onConfirm(prefixDate);
-    onOpenChange(false);
-  };
-
-  const handleConfirmVotes = () => {
-    onConfirmVotes?.(prefixDate);
-    onOpenChange(false);
-  };
 
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
@@ -68,31 +58,31 @@ export const DownloadDialog = React.forwardRef<
             </label>
           </div>
           <div className="flex flex-col gap-2">
-            <AlertDialogAction
-              onClick={handleConfirm}
-              className="flex items-center gap-2 justify-center"
+            <Button
+              onClick={() => onConfirm(prefixDate)}
+              className="flex items-center gap-2 justify-center w-full"
             >
               <FileDown size={16} />
               Download Participants CSV
               <span className="text-xs opacity-70">({participantCount} × {columnCount})</span>
-            </AlertDialogAction>
+            </Button>
             {onConfirmVotes && (
-              <AlertDialogAction
-                onClick={handleConfirmVotes}
-                className="flex items-center gap-2 justify-center"
+              <Button
+                onClick={() => onConfirmVotes(prefixDate)}
+                className="flex items-center gap-2 justify-center w-full"
               >
                 <FileDown size={16} />
                 Download Votes CSV
                 {statementCount !== undefined && (
                   <span className="text-xs opacity-70">({participantCount} × {statementCount})</span>
                 )}
-              </AlertDialogAction>
+              </Button>
             )}
           </div>
         </div>
 
         <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogCancel>Close</AlertDialogCancel>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/components/showcase-lander/App.tsx
+++ b/src/components/showcase-lander/App.tsx
@@ -69,6 +69,7 @@ const App: React.FC = () => {
         pipelineData: parsed.allEmbeddings,
         fullDimensionEmbeddings: parsed.fullDimensionEmbeddings,
         obsColumns: parsed.obsColumns,
+        conversationId: parsed.conversationId,
       });
     } catch (err) {
       console.error('Failed to load h5ad file:', err);

--- a/src/lib/duckdb.ts
+++ b/src/lib/duckdb.ts
@@ -220,6 +220,38 @@ export async function getVotesForParticipants(
 
 
 /**
+ * Get all votes from the votes table.
+ * @param kedroBaseUrl - Optional Kedro base URL for API access
+ * @param pipelineId - Optional pipeline ID for Kedro API
+ * @returns Array of all vote rows
+ */
+export async function getAllVotes(
+  kedroBaseUrl?: string,
+  pipelineId?: string
+): Promise<{ participant_id: string; comment_id: string; vote: number }[]> {
+  if (!conn) await initializeDuckDB();
+  await ensureVotesTableLoaded(kedroBaseUrl, pipelineId);
+
+  const result = await conn!.query(`
+    SELECT participant_id, comment_id, vote
+    FROM votes
+    ORDER BY participant_id, comment_id
+  `);
+
+  const votes = [];
+  for (let i = 0; i < result.numRows; i++) {
+    const participant_id = result.getChild('participant_id')?.get(i)?.toString();
+    const comment_id = result.getChild('comment_id')?.get(i)?.toString();
+    const rawVote = result.getChild('vote')?.get(i);
+    const vote = typeof rawVote === 'bigint' ? Number(rawVote) : rawVote as number;
+    if (participant_id !== undefined && comment_id !== undefined && vote !== undefined) {
+      votes.push({ participant_id, comment_id, vote });
+    }
+  }
+  return votes;
+}
+
+/**
  * Convert vote number to vote type string
  */
 function getVoteType(vote: number): keyof typeof VOTE_COLORS {

--- a/src/lib/h5ad-loader.ts
+++ b/src/lib/h5ad-loader.ts
@@ -19,6 +19,8 @@ export type H5adData = {
   fullDimensionEmbeddings: Record<string, [string, number[]][]>;
   /** Per-participant metadata columns from obs/ with type metadata */
   obsColumns: Record<string, ObsColumnInfo>;
+  /** Optional conversation identifier from uns['conversation_id'] */
+  conversationId?: string;
 };
 
 /**
@@ -351,7 +353,12 @@ export async function loadH5adFile(
     // --- Read votes from uns/votes ---
     const votesRows = readVotes(file);
 
-    return { dataset, statements, votesRows, availableEmbeddings, allEmbeddings, fullDimensionEmbeddings, obsColumns };
+    // --- Read conversation_id from uns ---
+    const unsGroup = file.get('uns') as Group | null;
+    const convIdDs = unsGroup?.get('conversation_id') as Dataset | null;
+    const conversationId = convIdDs ? String(convIdDs.value) : undefined;
+
+    return { dataset, statements, votesRows, availableEmbeddings, allEmbeddings, fullDimensionEmbeddings, obsColumns, conversationId };
   } finally {
     if (file) {
       file.close();


### PR DESCRIPTION
## Summary

- Adds a **Download Votes CSV** button to the existing download modal alongside the participants CSV button
- Adds a **Switch toggle** to prefix filenames with today's date (`YYYY-MM-DD-`)
- Uses `conversation_id` from the h5ad file as a filename prefix when available (e.g. `my-convo-vote-matrix.csv`)
- Reads `uns['conversation_id']` from h5ad files and threads it through to the download modal

## Vote matrix format

```
participant_id,stmt_1,stmt_2,...
p001,1,-1,
p002,,1,-1
```

Rows = participants, columns = statement IDs, values = `1`/`-1`/`0` or empty (no vote).

## Test plan

- [ ] Load an `.h5ad` file in Perspective Explorer
- [ ] Open the download modal — verify both buttons appear
- [ ] Download `vote-matrix.csv` and verify row/column structure and vote values
- [ ] Verify `participants.csv` still works
- [ ] Toggle the date-prefix switch and confirm filenames change
- [ ] `npm run build` passes with no TypeScript errors

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code) (~350 words of LLM output from ~600 words of human prompt)