### PR TITLE
feat: spotlight tool mode for D3Map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 ### Added
 
-- Spotlight mode for D3Map: a circle-follows-cursor selection tool where hovering selects all points within the circle radius; on touch, single-finger tracks the ring and two-finger pinch resizes it. Exposed via `mode="spotlight"` and `spotlightRadius` props; explored in the new `SpotlightModeSelection` Storybook story.
 - `useDruidWorker` hook and its worker script moved into the `reddwarf-ts` package (`reddwarf-ts/react` entry point); the app now re-exports from there.
 - Reduction animates live on the map: the recompute dialog closes when Run is clicked, and intermediate point positions are streamed from the worker every 10 iterations and displayed directly on the map. A progress pill at the bottom of the map shows "Building KNN graph…" then a 0–100 % progress bar during iteration. The final result is registered as a named projection as before.
 - Annoy KNN backend now exposes its parameters (`numTrees`, `maxPointsPerLeaf`, `seed`) in the recompute dialog, matching the HNSW pattern. Switching backends shows that backend's params immediately; values are forwarded as `knn_params` to PaCMAP and LocalMAP. HNSW params expanded to include `m` and `seed`.
@@ -30,6 +29,8 @@
 - Prev/next navigation buttons on `FloatingModal` for touch-friendly statement cycling in votes layer mode ([#27](https://github.com/patcon/polislike-human-cartography-prototype-v2/issues/27)).
   - Extracted shared `cycleStatement` callback so keyboard arrow keys and buttons use the same logic.
   - `onPrev` / `onNext` are optional injected props — buttons only render when provided, keeping the modal reusable for other contexts.
+- Spotlight mode for D3Map: a circle-follows-cursor selection tool where hovering selects all points within the circle radius; on touch, single-finger tracks the ring and two-finger pinch resizes it. Exposed via `mode="spotlight"` and `spotlightRadius` props; explored in the new `SpotlightModeSelection` Storybook story.
+- `spotlightPersist` prop for spotlight mode: when enabled, the circle and its selection stay frozen after all fingers lift; the next touch resumes from the last position. Story panel includes a matching checkbox toggle.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Spotlight mode for D3Map: a circle-follows-cursor selection tool where hovering selects all points within the circle radius; on touch, single-finger tracks the ring and two-finger pinch resizes it. Exposed via `mode="spotlight"` and `spotlightRadius` props; explored in the new `SpotlightModeSelection` Storybook story.
 - `useDruidWorker` hook and its worker script moved into the `reddwarf-ts` package (`reddwarf-ts/react` entry point); the app now re-exports from there.
 - Reduction animates live on the map: the recompute dialog closes when Run is clicked, and intermediate point positions are streamed from the worker every 10 iterations and displayed directly on the map. A progress pill at the bottom of the map shows "Building KNN graph…" then a 0–100 % progress bar during iteration. The final result is registered as a named projection as before.
 - Annoy KNN backend now exposes its parameters (`numTrees`, `maxPointsPerLeaf`, `seed`) in the recompute dialog, matching the HNSW pattern. Switching backends shows that backend's params immediately; values are forwarded as `knn_params` to PaCMAP and LocalMAP. HNSW params expanded to include `m` and `seed`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
   - `onPrev` / `onNext` are optional injected props — buttons only render when provided, keeping the modal reusable for other contexts.
 - Spotlight mode for D3Map: a circle-follows-cursor selection tool where hovering selects all points within the circle radius; on touch, single-finger tracks the ring and two-finger pinch resizes it. Exposed via `mode="spotlight"` and `spotlightRadius` props; explored in the new `SpotlightModeSelection` Storybook story.
 - `spotlightPersist` prop for spotlight mode: when enabled, the circle and its selection stay frozen after all fingers lift; the next touch resumes from the last position. Story panel includes a matching checkbox toggle.
+- Spotlight touch mechanic reworked as a similarity transform: single touch grabs at the contact point (preserving offset from circle center), two touches apply an incremental scale + rotation + translation each frame so the circle behaves like a sticker layer rather than anchoring to the first finger. No special "primary touch" — both fingers are treated symmetrically.
 
 ### Changed
 

--- a/src/components/convo-explorer/D3Map.stories.tsx
+++ b/src/components/convo-explorer/D3Map.stories.tsx
@@ -20,7 +20,7 @@ const meta: Meta<D3MapStoryArgs> = {
   argTypes: {
     mode: {
       control: { type: "radio" },
-      options: ["move", "paint"],
+      options: ["move", "paint", "spotlight"],
       description: "Map interaction mode",
     },
     kedroBaseUrl: {
@@ -127,6 +127,101 @@ export const PaintModeWithSelection: Story = {
           }}
         >
           Selected IDs: {selectedIds.join(", ")}
+        </div>
+      </>
+    );
+  },
+};
+
+/** Circle-follows-cursor selection: hover to select, pinch to resize on touch */
+export const SpotlightModeSelection: Story = {
+  render: (args) => {
+    const decodedArgs = decodeStorybookArgs(args);
+    const { kedroBaseUrl, pipelineId, ...d3MapArgs } = decodedArgs;
+    const { pipelines, loading: pipelinesLoading } = usePipelineOptions(kedroBaseUrl, 'bestkmeans');
+    const { dataset, loading, error } = useStorybookDataLoader(kedroBaseUrl, pipelineId);
+    const [selectedIds, setSelectedIds] = React.useState<number[]>([]);
+    const [radius, setRadius] = React.useState(60);
+    const [debugState, setDebugState] = React.useState<{
+      event: string;
+      touchCount: number;
+      primaryId: number | null;
+      pinchRefDistance: number | null;
+      pinchRefRadius: number | null;
+      currentRadius: number;
+    } | null>(null);
+
+    React.useEffect(() => {
+      if (pipelines.length > 0) {
+        console.log('Available pipelines:', pipelines);
+      }
+    }, [pipelines]);
+
+    if (loading || pipelinesLoading) return <div>Loading...</div>;
+    if (error) return <div>Error: {error}</div>;
+    if (!dataset) return <div>No data available</div>;
+
+    return (
+      <>
+        <D3Map
+          {...d3MapArgs}
+          data={dataset}
+          mode="spotlight"
+          spotlightRadius={radius}
+          onSelectionChange={(ids: (string | number)[]) => setSelectedIds(ids as number[])}
+          onSpotlightDebug={setDebugState}
+        />
+        <div
+          style={{
+            position: "absolute",
+            bottom: 10,
+            left: 10,
+            background: "rgba(255,255,255,0.9)",
+            padding: 8,
+            fontSize: 11,
+            fontFamily: "monospace",
+            display: "flex",
+            flexDirection: "column",
+            gap: 3,
+            borderRadius: 4,
+            minWidth: 220,
+            maxWidth: 320,
+            userSelect: "none",
+          }}
+        >
+          <label style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <span>Radius (slider): {radius}px</span>
+            <input
+              type="range"
+              min={20}
+              max={200}
+              value={radius}
+              onChange={(e) => setRadius(Number(e.target.value))}
+              style={{ width: 180 }}
+            />
+          </label>
+          <hr style={{ margin: "2px 0", border: "none", borderTop: "1px solid #ccc" }} />
+          {debugState ? (
+            <>
+              <div>event: <b>{debugState.event}</b></div>
+              <div>touches: <b>{debugState.touchCount}</b></div>
+              <div>primaryId: <b>{debugState.primaryId ?? "null"}</b></div>
+              <div>pinchRefDist: <b>{debugState.pinchRefDistance !== null ? debugState.pinchRefDistance.toFixed(1) : "null"}</b></div>
+              <div>pinchRefRadius: <b>{debugState.pinchRefRadius !== null ? debugState.pinchRefRadius.toFixed(1) : "null"}</b></div>
+              <div>currentRadius: <b>{debugState.currentRadius.toFixed(1)}</b></div>
+            </>
+          ) : (
+            <div style={{ color: "#999" }}>no touch events yet</div>
+          )}
+          <hr style={{ margin: "2px 0", border: "none", borderTop: "1px solid #ccc" }} />
+          <details>
+            <summary style={{ cursor: "pointer" }}>
+              Selected: {selectedIds.length} points
+            </summary>
+            <div style={{ marginTop: 4, wordBreak: "break-all", color: "#555" }}>
+              {selectedIds.join(", ") || "none"}
+            </div>
+          </details>
         </div>
       </>
     );

--- a/src/components/convo-explorer/D3Map.stories.tsx
+++ b/src/components/convo-explorer/D3Map.stories.tsx
@@ -192,6 +192,7 @@ export const SpotlightModeSelection: Story = {
           spotlightRadius={radius}
           spotlightPersist={persist}
           onSelectionChange={(ids: (string | number)[]) => setSelectedIds(ids as number[])}
+          onSpotlightRadiusChange={setRadius}
           onSpotlightDebug={handleDebug}
         />
         <div
@@ -212,25 +213,14 @@ export const SpotlightModeSelection: Story = {
             userSelect: "none",
           }}
         >
-          <label style={{ display: "flex", flexDirection: "column", gap: 2 }}>
-            <span>Radius (slider): {radius}px</span>
-            <input
-              type="range"
-              min={20}
-              max={200}
-              value={radius}
-              onChange={(e) => setRadius(Number(e.target.value))}
-              style={{ width: 180 }}
-            />
-          </label>
-          <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
-            <input
-              type="checkbox"
-              checked={persist}
-              onChange={(e) => setPersist(e.target.checked)}
-            />
-            Persist circle between touches
-          </label>
+          <details>
+            <summary style={{ cursor: "pointer" }}>
+              Selected: {selectedIds.length} points
+            </summary>
+            <div style={{ marginTop: 4, wordBreak: "break-all", color: "#555" }}>
+              {selectedIds.join(", ") || "none"}
+            </div>
+          </details>
           <hr style={{ margin: "2px 0", border: "none", borderTop: "1px solid #ccc" }} />
           {debugState ? (
             <>
@@ -284,14 +274,25 @@ export const SpotlightModeSelection: Story = {
             }
           </div>
           <hr style={{ margin: "2px 0", border: "none", borderTop: "1px solid #ccc" }} />
-          <details>
-            <summary style={{ cursor: "pointer" }}>
-              Selected: {selectedIds.length} points
-            </summary>
-            <div style={{ marginTop: 4, wordBreak: "break-all", color: "#555" }}>
-              {selectedIds.join(", ") || "none"}
-            </div>
-          </details>
+          <label style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <span>Radius: {Math.round(radius)}px</span>
+            <input
+              type="range"
+              min={10}
+              max={500}
+              value={radius}
+              onChange={(e) => setRadius(Number(e.target.value))}
+              style={{ width: 180 }}
+            />
+          </label>
+          <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <input
+              type="checkbox"
+              checked={persist}
+              onChange={(e) => setPersist(e.target.checked)}
+            />
+            Persist circle between touches
+          </label>
         </div>
       </>
     );

--- a/src/components/convo-explorer/D3Map.stories.tsx
+++ b/src/components/convo-explorer/D3Map.stories.tsx
@@ -146,10 +146,11 @@ export const SpotlightModeSelection: Story = {
     type DebugEntry = {
       event: string;
       touchCount: number;
-      primaryId: number | null;
-      pinchRefDistance: number | null;
-      pinchRefRadius: number | null;
       currentRadius: number;
+      cx: number;
+      cy: number;
+      grabOffsetX: number;
+      grabOffsetY: number;
     };
     const [debugState, setDebugState] = React.useState<DebugEntry | null>(null);
     const [debugLog, setDebugLog] = React.useState<string[]>([]);
@@ -157,7 +158,7 @@ export const SpotlightModeSelection: Story = {
 
     const handleDebug = React.useCallback((state: DebugEntry) => {
       setDebugState(state);
-      const line = `${state.event} | touches:${state.touchCount} primaryId:${state.primaryId ?? "null"} refDist:${state.pinchRefDistance !== null ? state.pinchRefDistance.toFixed(1) : "null"} refR:${state.pinchRefRadius !== null ? state.pinchRefRadius.toFixed(1) : "null"} r:${state.currentRadius.toFixed(1)}`;
+      const line = `${state.event} | touches:${state.touchCount} r:${state.currentRadius.toFixed(1)} cx:${state.cx.toFixed(1)} cy:${state.cy.toFixed(1)} grabX:${state.grabOffsetX.toFixed(1)} grabY:${state.grabOffsetY.toFixed(1)}`;
       setDebugLog(prev => [...prev.slice(-199), line]);
     }, []);
 
@@ -235,10 +236,9 @@ export const SpotlightModeSelection: Story = {
             <>
               <div>event: <b>{debugState.event}</b></div>
               <div>touches: <b>{debugState.touchCount}</b></div>
-              <div>primaryId: <b>{debugState.primaryId ?? "null"}</b></div>
-              <div>pinchRefDist: <b>{debugState.pinchRefDistance !== null ? debugState.pinchRefDistance.toFixed(1) : "null"}</b></div>
-              <div>pinchRefRadius: <b>{debugState.pinchRefRadius !== null ? debugState.pinchRefRadius.toFixed(1) : "null"}</b></div>
-              <div>currentRadius: <b>{debugState.currentRadius.toFixed(1)}</b></div>
+              <div>radius: <b>{debugState.currentRadius.toFixed(1)}</b></div>
+              <div>cx/cy: <b>{debugState.cx.toFixed(1)}, {debugState.cy.toFixed(1)}</b></div>
+              <div>grabOffset: <b>{debugState.grabOffsetX.toFixed(1)}, {debugState.grabOffsetY.toFixed(1)}</b></div>
             </>
           ) : (
             <div style={{ color: "#999" }}>no touch events yet</div>

--- a/src/components/convo-explorer/D3Map.stories.tsx
+++ b/src/components/convo-explorer/D3Map.stories.tsx
@@ -142,6 +142,7 @@ export const SpotlightModeSelection: Story = {
     const { dataset, loading, error } = useStorybookDataLoader(kedroBaseUrl, pipelineId);
     const [selectedIds, setSelectedIds] = React.useState<number[]>([]);
     const [radius, setRadius] = React.useState(60);
+    const [persist, setPersist] = React.useState(false);
     type DebugEntry = {
       event: string;
       touchCount: number;
@@ -188,6 +189,7 @@ export const SpotlightModeSelection: Story = {
           data={dataset}
           mode="spotlight"
           spotlightRadius={radius}
+          spotlightPersist={persist}
           onSelectionChange={(ids: (string | number)[]) => setSelectedIds(ids as number[])}
           onSpotlightDebug={handleDebug}
         />
@@ -219,6 +221,14 @@ export const SpotlightModeSelection: Story = {
               onChange={(e) => setRadius(Number(e.target.value))}
               style={{ width: 180 }}
             />
+          </label>
+          <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <input
+              type="checkbox"
+              checked={persist}
+              onChange={(e) => setPersist(e.target.checked)}
+            />
+            Persist circle between touches
           </label>
           <hr style={{ margin: "2px 0", border: "none", borderTop: "1px solid #ccc" }} />
           {debugState ? (

--- a/src/components/convo-explorer/D3Map.stories.tsx
+++ b/src/components/convo-explorer/D3Map.stories.tsx
@@ -142,20 +142,40 @@ export const SpotlightModeSelection: Story = {
     const { dataset, loading, error } = useStorybookDataLoader(kedroBaseUrl, pipelineId);
     const [selectedIds, setSelectedIds] = React.useState<number[]>([]);
     const [radius, setRadius] = React.useState(60);
-    const [debugState, setDebugState] = React.useState<{
+    type DebugEntry = {
       event: string;
       touchCount: number;
       primaryId: number | null;
       pinchRefDistance: number | null;
       pinchRefRadius: number | null;
       currentRadius: number;
-    } | null>(null);
+    };
+    const [debugState, setDebugState] = React.useState<DebugEntry | null>(null);
+    const [debugLog, setDebugLog] = React.useState<string[]>([]);
+    const [copied, setCopied] = React.useState(false);
+
+    const handleDebug = React.useCallback((state: DebugEntry) => {
+      setDebugState(state);
+      const line = `${state.event} | touches:${state.touchCount} primaryId:${state.primaryId ?? "null"} refDist:${state.pinchRefDistance !== null ? state.pinchRefDistance.toFixed(1) : "null"} refR:${state.pinchRefRadius !== null ? state.pinchRefRadius.toFixed(1) : "null"} r:${state.currentRadius.toFixed(1)}`;
+      setDebugLog(prev => [...prev.slice(-199), line]);
+    }, []);
 
     React.useEffect(() => {
       if (pipelines.length > 0) {
         console.log('Available pipelines:', pipelines);
       }
     }, [pipelines]);
+
+    function fallbackCopy(text: string) {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      ta.style.cssText = "position:fixed;top:-9999px;left:-9999px";
+      document.body.appendChild(ta);
+      ta.focus();
+      ta.select();
+      document.execCommand("copy");
+      document.body.removeChild(ta);
+    }
 
     if (loading || pipelinesLoading) return <div>Loading...</div>;
     if (error) return <div>Error: {error}</div>;
@@ -169,7 +189,7 @@ export const SpotlightModeSelection: Story = {
           mode="spotlight"
           spotlightRadius={radius}
           onSelectionChange={(ids: (string | number)[]) => setSelectedIds(ids as number[])}
-          onSpotlightDebug={setDebugState}
+          onSpotlightDebug={handleDebug}
         />
         <div
           style={{
@@ -213,6 +233,46 @@ export const SpotlightModeSelection: Story = {
           ) : (
             <div style={{ color: "#999" }}>no touch events yet</div>
           )}
+          <hr style={{ margin: "2px 0", border: "none", borderTop: "1px solid #ccc" }} />
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 4 }}>
+            <span>Event log ({debugLog.length})</span>
+            <div style={{ display: "flex", gap: 4 }}>
+              <button
+                onClick={() => {
+                  const text = debugLog.join("\n");
+                  if (navigator.clipboard) {
+                    navigator.clipboard.writeText(text).catch(() => fallbackCopy(text));
+                  } else {
+                    fallbackCopy(text);
+                  }
+                  setCopied(true);
+                  setTimeout(() => setCopied(false), 1500);
+                }}
+                style={{ fontSize: 10, padding: "1px 6px", cursor: "pointer" }}
+              >
+                {copied ? "Copied!" : "Copy"}
+              </button>
+              <button
+                onClick={() => setDebugLog([])}
+                style={{ fontSize: 10, padding: "1px 6px", cursor: "pointer" }}
+              >
+                Clear
+              </button>
+            </div>
+          </div>
+          <div style={{
+            maxHeight: 120,
+            overflowY: "auto",
+            fontSize: 10,
+            color: "#444",
+            lineHeight: 1.4,
+            wordBreak: "break-all",
+          }}>
+            {debugLog.length === 0
+              ? <span style={{ color: "#999" }}>—</span>
+              : [...debugLog].reverse().map((line, i) => <div key={i}>{line}</div>)
+            }
+          </div>
           <hr style={{ margin: "2px 0", border: "none", borderTop: "1px solid #ccc" }} />
           <details>
             <summary style={{ cursor: "pointer" }}>

--- a/src/components/convo-explorer/D3Map.tsx
+++ b/src/components/convo-explorer/D3Map.tsx
@@ -19,7 +19,9 @@ const MIN_CIRCLE_RADIUS = 0.5; // prevent sub-pixel circles that vanish on mobil
 type D3MapProps = {
   /** Dataset points in the format [[i, [x, y]], ...] */
   data: [string, [number, number]][];
-  mode?: "move" | "paint";
+  mode?: "move" | "paint" | "spotlight";
+  /** Radius in SVG pixels for the spotlight selection circle (spotlight mode only) */
+  spotlightRadius?: number;
   /** Color indices parallel to data: null = default color, number = palette index (groups/votes) or 0-1 values (metrics) */
   pointColors?: (number | null)[];
   /** Color palette to use for rendering points */
@@ -65,6 +67,8 @@ type D3MapProps = {
   displayMask?: boolean[];
   /** Color for unpainted points in groups mode. Defaults to UNPAINTED_COLOR (black). */
   unpaintedColor?: string;
+  /** Debug callback fired on every spotlight touch/pointer event with internal state (spotlight mode only) */
+  onSpotlightDebug?: (state: { event: string; touchCount: number; primaryId: number | null; pinchRefDistance: number | null; pinchRefRadius: number | null; currentRadius: number }) => void;
 };
 
 const PREFERRED_KEDRO_PIPELINE = 'mean_localmap_bestkmeans';
@@ -96,6 +100,8 @@ export const D3Map: React.FC<D3MapProps> = ({
   liveData,
   displayMask,
   unpaintedColor = UNPAINTED_COLOR,
+  spotlightRadius = 60,
+  onSpotlightDebug,
 }) => {
   const svgRef = React.useRef<SVGSVGElement>(null);
   const containerRef = React.useRef<d3.Selection<SVGGElement, unknown, null, undefined> | null>(null);
@@ -593,6 +599,8 @@ export const D3Map: React.FC<D3MapProps> = ({
     const zoom = d3.zoom<SVGSVGElement, unknown>()
       .scaleExtent([0.5, 15])
       .filter((event) => {
+        // Spotlight mode owns all pointer interactions — block pan/zoom entirely
+        if (modeRef.current === "spotlight") return false;
         /**
          * Here's what we do for every zoom event:
          * - all wheel events = YES, in any mode
@@ -823,6 +831,226 @@ export const D3Map: React.FC<D3MapProps> = ({
       lassoStateRef.current.cleanup = null;
     }
   }, [mode, onSelectionChange, xScale, yScale, onLassoStart, onLassoEnd, displayMask]);
+
+  // --- Spotlight mode ---
+  React.useEffect(() => {
+    if (!svgRef.current || !containerRef.current) return;
+    if (mode !== "spotlight") return;
+
+    const svg = d3.select(svgRef.current);
+    const container = containerRef.current;
+    const svgNode = svgRef.current;
+
+    // Prevent native touch scroll/pan while spotlight is active
+    svgNode.style.touchAction = "none";
+
+    const ring = svg.append("circle")
+      .attr("class", "spotlight-ring")
+      .attr("fill", "rgba(255, 220, 0, 0.08)")
+      .attr("stroke", "#FFCC00")
+      .attr("stroke-width", 2)
+      .attr("stroke-dasharray", "6 3")
+      .attr("cx", -9999)
+      .attr("cy", -9999)
+      .attr("r", spotlightRadius)
+      .style("pointer-events", "none");
+
+    let currentRadius = spotlightRadius;
+    let currentCx = -9999;
+    let currentCy = -9999;
+    // Touch Events give us event.touches (all active touches) on every event,
+    // so we don't need a manual map — no iOS pointer-ownership-transfer issues.
+    let primaryTouchId: number | null = null;
+    let pinchRefDistance: number | null = null;
+    let pinchRefRadius: number | null = null;
+
+    function debug(eventName: string, touchCount: number) {
+      onSpotlightDebug?.({ event: eventName, touchCount, primaryId: primaryTouchId, pinchRefDistance, pinchRefRadius, currentRadius });
+    }
+
+    function touchToSVG(touch: Touch): [number, number] {
+      const rect = svgNode.getBoundingClientRect();
+      return [touch.clientX - rect.left, touch.clientY - rect.top];
+    }
+
+    function findTouch(list: TouchList, id: number | null): Touch | null {
+      if (id === null) return null;
+      for (let i = 0; i < list.length; i++) {
+        if (list[i].identifier === id) return list[i];
+      }
+      return null;
+    }
+
+    function updateSelection(cx: number, cy: number, radius: number) {
+      currentCx = cx;
+      currentCy = cy;
+      ring.attr("cx", cx).attr("cy", cy).attr("r", radius);
+      const transform = d3.zoomTransform(container.node()!);
+      const selected = (container.selectAll("circle").data() as any[]).filter((d: any) => {
+        if (displayMask && !displayMask[d.originalIndex]) return false;
+        const sx = transform.applyX((container as any).xScale(d.x));
+        const sy = transform.applyY((container as any).yScale(d.y));
+        return Math.sqrt((sx - cx) ** 2 + (sy - cy) ** 2) <= radius;
+      });
+      onSelectionChange?.(selected.map((d: any) => d.i));
+    }
+
+    // --- Touch Events (handles multi-touch reliably via event.touches) ---
+    function handleTouchStart(event: TouchEvent) {
+      event.preventDefault();
+      const n = event.touches.length;
+
+      if (n === 1) {
+        primaryTouchId = event.touches[0].identifier;
+        pinchRefDistance = null;
+        pinchRefRadius = null;
+        const [px, py] = touchToSVG(event.touches[0]);
+        updateSelection(px, py, currentRadius);
+        debug("touch:start:1", n);
+      } else if (n === 2) {
+        // Second finger just landed — lock in the scale reference
+        const primary = findTouch(event.touches, primaryTouchId) ?? event.touches[0];
+        primaryTouchId = primary.identifier;
+        const secondary = [...event.touches].find(t => t.identifier !== primaryTouchId)!;
+        const [p1x, p1y] = touchToSVG(primary);
+        const [p2x, p2y] = touchToSVG(secondary);
+        const dx = p1x - p2x;
+        const dy = p1y - p2y;
+        pinchRefDistance = Math.max(1, Math.sqrt(dx * dx + dy * dy));
+        pinchRefRadius = currentRadius;
+        debug("touch:start:2", n);
+      }
+    }
+
+    function handleTouchMove(event: TouchEvent) {
+      event.preventDefault();
+      const n = event.touches.length;
+
+      if (n === 1) {
+        primaryTouchId = event.touches[0].identifier;
+        const [px, py] = touchToSVG(event.touches[0]);
+        updateSelection(px, py, currentRadius);
+        debug("touch:move:1", n);
+      } else if (n >= 2) {
+        const primary = findTouch(event.touches, primaryTouchId) ?? event.touches[0];
+        const secondary = [...event.touches].find(t => t.identifier !== primary.identifier);
+        if (!secondary) return;
+
+        // Lazy capture only if reference is genuinely missing (not from a spurious reset)
+        if (pinchRefDistance === null || pinchRefRadius === null) {
+          const [p1x, p1y] = touchToSVG(primary);
+          const [p2x, p2y] = touchToSVG(secondary);
+          const dx = p1x - p2x;
+          const dy = p1y - p2y;
+          pinchRefDistance = Math.max(1, Math.sqrt(dx * dx + dy * dy));
+          pinchRefRadius = currentRadius;
+          // Skip radius update on this frame — ref just captured, ratio would be 1
+          debug("touch:move:2:ref", n);
+          return;
+        }
+
+        const [p1x, p1y] = touchToSVG(primary);
+        const [p2x, p2y] = touchToSVG(secondary);
+        const dx = p1x - p2x;
+        const dy = p1y - p2y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        currentRadius = Math.max(10, Math.min(500, pinchRefRadius * (dist / pinchRefDistance)));
+        updateSelection(p1x, p1y, currentRadius);
+        debug("touch:move:2", n);
+      }
+    }
+
+    function handleTouchEnd(event: TouchEvent) {
+      const n = event.touches.length;
+      if (n === 0) {
+        ring.attr("cx", -9999).attr("cy", -9999);
+        currentCx = -9999;
+        currentCy = -9999;
+        primaryTouchId = null;
+        pinchRefDistance = null;
+        pinchRefRadius = null;
+        onSelectionChange?.([]);
+        debug("touch:end:0", n);
+      } else if (n === 1) {
+        // Second finger lifted — reset pinch baseline, keep tracking first finger
+        pinchRefDistance = null;
+        pinchRefRadius = null;
+        primaryTouchId = event.touches[0].identifier;
+        const [px, py] = touchToSVG(event.touches[0]);
+        updateSelection(px, py, currentRadius);
+        debug("touch:end:1", n);
+      }
+    }
+
+    function handleTouchCancel(event: TouchEvent) {
+      // touchcancel fires spuriously on iOS (system gestures, notifications, etc.)
+      // Only reset state if all touches are genuinely gone; preserve pinch reference otherwise
+      debug(`touch:cancel:${event.touches.length}`, event.touches.length);
+      if (event.touches.length === 0) {
+        ring.attr("cx", -9999).attr("cy", -9999);
+        currentCx = -9999;
+        currentCy = -9999;
+        primaryTouchId = null;
+        pinchRefDistance = null;
+        pinchRefRadius = null;
+        onSelectionChange?.([]);
+      }
+    }
+
+    // --- Mouse (Pointer Events, mouse only) ---
+    function handlePointerEnter(event: PointerEvent) {
+      if (event.pointerType !== "mouse") return;
+      const [px, py] = d3.pointer(event, svgNode);
+      updateSelection(px, py, currentRadius);
+    }
+
+    function handlePointerMove(event: PointerEvent) {
+      if (event.pointerType !== "mouse") return;
+      const [px, py] = d3.pointer(event, svgNode);
+      updateSelection(px, py, currentRadius);
+    }
+
+    function handlePointerLeave(event: PointerEvent) {
+      if (event.pointerType !== "mouse") return;
+      ring.attr("cx", -9999).attr("cy", -9999);
+      currentCx = -9999;
+      currentCy = -9999;
+      onSelectionChange?.([]);
+    }
+
+    function handleWheel(event: WheelEvent) {
+      event.preventDefault();
+      const factor = event.deltaMode === 0 ? 0.002 : 0.06;
+      currentRadius = Math.max(10, Math.min(500, currentRadius * (1 - event.deltaY * factor)));
+      if (currentCx !== -9999) {
+        updateSelection(currentCx, currentCy, currentRadius);
+      } else {
+        ring.attr("r", currentRadius);
+      }
+    }
+
+    svgNode.addEventListener("touchstart", handleTouchStart, { passive: false });
+    svgNode.addEventListener("touchmove", handleTouchMove, { passive: false });
+    svgNode.addEventListener("touchend", handleTouchEnd);
+    svgNode.addEventListener("touchcancel", handleTouchCancel);
+    svgNode.addEventListener("pointerenter", handlePointerEnter);
+    svgNode.addEventListener("pointermove", handlePointerMove);
+    svgNode.addEventListener("pointerleave", handlePointerLeave);
+    svgNode.addEventListener("wheel", handleWheel, { passive: false });
+
+    return () => {
+      ring.remove();
+      svgNode.style.touchAction = "";
+      svgNode.removeEventListener("touchstart", handleTouchStart);
+      svgNode.removeEventListener("touchmove", handleTouchMove);
+      svgNode.removeEventListener("touchend", handleTouchEnd);
+      svgNode.removeEventListener("touchcancel", handleTouchCancel);
+      svgNode.removeEventListener("pointerenter", handlePointerEnter);
+      svgNode.removeEventListener("pointermove", handlePointerMove);
+      svgNode.removeEventListener("pointerleave", handlePointerLeave);
+      svgNode.removeEventListener("wheel", handleWheel);
+    };
+  }, [mode, spotlightRadius, onSelectionChange, onSpotlightDebug, displayMask]);
 
   // --- Update colors on pointColors or palette change ---
   React.useEffect(() => {

--- a/src/components/convo-explorer/D3Map.tsx
+++ b/src/components/convo-explorer/D3Map.tsx
@@ -107,6 +107,25 @@ export const D3Map: React.FC<D3MapProps> = ({
   const containerRef = React.useRef<d3.Selection<SVGGElement, unknown, null, undefined> | null>(null);
   const lassoRectRef = React.useRef<SVGRectElement | null>(null);
   const modeRef = React.useRef(mode);
+
+  // Spotlight: mutable touch state lives in a ref so it survives effect re-runs
+  const spotlightStateRef = React.useRef({
+    currentRadius: spotlightRadius,
+    currentCx: -9999,
+    currentCy: -9999,
+    primaryTouchId: null as number | null,
+    pinchRefDistance: null as number | null,
+    pinchRefRadius: null as number | null,
+  });
+  // Keep callback refs so spotlight effect doesn't re-run when they change identity
+  const onSelectionChangeRef = React.useRef(onSelectionChange);
+  const onSpotlightDebugRef = React.useRef(onSpotlightDebug);
+  const displayMaskRef = React.useRef(displayMask);
+  React.useEffect(() => { onSelectionChangeRef.current = onSelectionChange; }, [onSelectionChange]);
+  React.useEffect(() => { onSpotlightDebugRef.current = onSpotlightDebug; }, [onSpotlightDebug]);
+  React.useEffect(() => { displayMaskRef.current = displayMask; }, [displayMask]);
+  // Sync slider value into state ref without re-running the spotlight effect
+  React.useEffect(() => { spotlightStateRef.current.currentRadius = spotlightRadius; }, [spotlightRadius]);
   const lassoStateRef = React.useRef<{
     path: d3.Selection<SVGPathElement, unknown, null, undefined> | null;
     coords: [number, number][];
@@ -852,20 +871,15 @@ export const D3Map: React.FC<D3MapProps> = ({
       .attr("stroke-dasharray", "6 3")
       .attr("cx", -9999)
       .attr("cy", -9999)
-      .attr("r", spotlightRadius)
+      .attr("r", spotlightStateRef.current.currentRadius)
       .style("pointer-events", "none");
 
-    let currentRadius = spotlightRadius;
-    let currentCx = -9999;
-    let currentCy = -9999;
-    // Touch Events give us event.touches (all active touches) on every event,
-    // so we don't need a manual map — no iOS pointer-ownership-transfer issues.
-    let primaryTouchId: number | null = null;
-    let pinchRefDistance: number | null = null;
-    let pinchRefRadius: number | null = null;
+    // All mutable touch state lives in spotlightStateRef so it survives effect re-runs.
+    // Callbacks are accessed via refs so they never appear in deps and never trigger re-runs.
+    const s = spotlightStateRef.current;
 
     function debug(eventName: string, touchCount: number) {
-      onSpotlightDebug?.({ event: eventName, touchCount, primaryId: primaryTouchId, pinchRefDistance, pinchRefRadius, currentRadius });
+      onSpotlightDebugRef.current?.({ event: eventName, touchCount, primaryId: s.primaryTouchId, pinchRefDistance: s.pinchRefDistance, pinchRefRadius: s.pinchRefRadius, currentRadius: s.currentRadius });
     }
 
     function touchToSVG(touch: Touch): [number, number] {
@@ -882,17 +896,17 @@ export const D3Map: React.FC<D3MapProps> = ({
     }
 
     function updateSelection(cx: number, cy: number, radius: number) {
-      currentCx = cx;
-      currentCy = cy;
+      s.currentCx = cx;
+      s.currentCy = cy;
       ring.attr("cx", cx).attr("cy", cy).attr("r", radius);
       const transform = d3.zoomTransform(container.node()!);
       const selected = (container.selectAll("circle").data() as any[]).filter((d: any) => {
-        if (displayMask && !displayMask[d.originalIndex]) return false;
+        if (displayMaskRef.current && !displayMaskRef.current[d.originalIndex]) return false;
         const sx = transform.applyX((container as any).xScale(d.x));
         const sy = transform.applyY((container as any).yScale(d.y));
         return Math.sqrt((sx - cx) ** 2 + (sy - cy) ** 2) <= radius;
       });
-      onSelectionChange?.(selected.map((d: any) => d.i));
+      onSelectionChangeRef.current?.(selected.map((d: any) => d.i));
     }
 
     // --- Touch Events (handles multi-touch reliably via event.touches) ---
@@ -901,23 +915,22 @@ export const D3Map: React.FC<D3MapProps> = ({
       const n = event.touches.length;
 
       if (n === 1) {
-        primaryTouchId = event.touches[0].identifier;
-        pinchRefDistance = null;
-        pinchRefRadius = null;
+        s.primaryTouchId = event.touches[0].identifier;
+        s.pinchRefDistance = null;
+        s.pinchRefRadius = null;
         const [px, py] = touchToSVG(event.touches[0]);
-        updateSelection(px, py, currentRadius);
+        updateSelection(px, py, s.currentRadius);
         debug("touch:start:1", n);
       } else if (n === 2) {
-        // Second finger just landed — lock in the scale reference
-        const primary = findTouch(event.touches, primaryTouchId) ?? event.touches[0];
-        primaryTouchId = primary.identifier;
-        const secondary = [...event.touches].find(t => t.identifier !== primaryTouchId)!;
+        const primary = findTouch(event.touches, s.primaryTouchId) ?? event.touches[0];
+        s.primaryTouchId = primary.identifier;
+        const secondary = [...event.touches].find(t => t.identifier !== s.primaryTouchId)!;
         const [p1x, p1y] = touchToSVG(primary);
         const [p2x, p2y] = touchToSVG(secondary);
         const dx = p1x - p2x;
         const dy = p1y - p2y;
-        pinchRefDistance = Math.max(1, Math.sqrt(dx * dx + dy * dy));
-        pinchRefRadius = currentRadius;
+        s.pinchRefDistance = Math.max(1, Math.sqrt(dx * dx + dy * dy));
+        s.pinchRefRadius = s.currentRadius;
         debug("touch:start:2", n);
       }
     }
@@ -927,24 +940,22 @@ export const D3Map: React.FC<D3MapProps> = ({
       const n = event.touches.length;
 
       if (n === 1) {
-        primaryTouchId = event.touches[0].identifier;
+        s.primaryTouchId = event.touches[0].identifier;
         const [px, py] = touchToSVG(event.touches[0]);
-        updateSelection(px, py, currentRadius);
+        updateSelection(px, py, s.currentRadius);
         debug("touch:move:1", n);
       } else if (n >= 2) {
-        const primary = findTouch(event.touches, primaryTouchId) ?? event.touches[0];
+        const primary = findTouch(event.touches, s.primaryTouchId) ?? event.touches[0];
         const secondary = [...event.touches].find(t => t.identifier !== primary.identifier);
         if (!secondary) return;
 
-        // Lazy capture only if reference is genuinely missing (not from a spurious reset)
-        if (pinchRefDistance === null || pinchRefRadius === null) {
+        if (s.pinchRefDistance === null || s.pinchRefRadius === null) {
           const [p1x, p1y] = touchToSVG(primary);
           const [p2x, p2y] = touchToSVG(secondary);
           const dx = p1x - p2x;
           const dy = p1y - p2y;
-          pinchRefDistance = Math.max(1, Math.sqrt(dx * dx + dy * dy));
-          pinchRefRadius = currentRadius;
-          // Skip radius update on this frame — ref just captured, ratio would be 1
+          s.pinchRefDistance = Math.max(1, Math.sqrt(dx * dx + dy * dy));
+          s.pinchRefRadius = s.currentRadius;
           debug("touch:move:2:ref", n);
           return;
         }
@@ -954,8 +965,8 @@ export const D3Map: React.FC<D3MapProps> = ({
         const dx = p1x - p2x;
         const dy = p1y - p2y;
         const dist = Math.sqrt(dx * dx + dy * dy);
-        currentRadius = Math.max(10, Math.min(500, pinchRefRadius * (dist / pinchRefDistance)));
-        updateSelection(p1x, p1y, currentRadius);
+        s.currentRadius = Math.max(10, Math.min(500, s.pinchRefRadius * (dist / s.pinchRefDistance)));
+        updateSelection(p1x, p1y, s.currentRadius);
         debug("touch:move:2", n);
       }
     }
@@ -964,36 +975,34 @@ export const D3Map: React.FC<D3MapProps> = ({
       const n = event.touches.length;
       if (n === 0) {
         ring.attr("cx", -9999).attr("cy", -9999);
-        currentCx = -9999;
-        currentCy = -9999;
-        primaryTouchId = null;
-        pinchRefDistance = null;
-        pinchRefRadius = null;
-        onSelectionChange?.([]);
+        s.currentCx = -9999;
+        s.currentCy = -9999;
+        s.primaryTouchId = null;
+        s.pinchRefDistance = null;
+        s.pinchRefRadius = null;
+        onSelectionChangeRef.current?.([]);
         debug("touch:end:0", n);
       } else if (n === 1) {
-        // Second finger lifted — reset pinch baseline, keep tracking first finger
-        pinchRefDistance = null;
-        pinchRefRadius = null;
-        primaryTouchId = event.touches[0].identifier;
+        s.pinchRefDistance = null;
+        s.pinchRefRadius = null;
+        s.primaryTouchId = event.touches[0].identifier;
         const [px, py] = touchToSVG(event.touches[0]);
-        updateSelection(px, py, currentRadius);
+        updateSelection(px, py, s.currentRadius);
         debug("touch:end:1", n);
       }
     }
 
     function handleTouchCancel(event: TouchEvent) {
-      // touchcancel fires spuriously on iOS (system gestures, notifications, etc.)
-      // Only reset state if all touches are genuinely gone; preserve pinch reference otherwise
+      // Only reset if all touches are gone; spurious cancels mid-gesture should be ignored
       debug(`touch:cancel:${event.touches.length}`, event.touches.length);
       if (event.touches.length === 0) {
         ring.attr("cx", -9999).attr("cy", -9999);
-        currentCx = -9999;
-        currentCy = -9999;
-        primaryTouchId = null;
-        pinchRefDistance = null;
-        pinchRefRadius = null;
-        onSelectionChange?.([]);
+        s.currentCx = -9999;
+        s.currentCy = -9999;
+        s.primaryTouchId = null;
+        s.pinchRefDistance = null;
+        s.pinchRefRadius = null;
+        onSelectionChangeRef.current?.([]);
       }
     }
 
@@ -1001,31 +1010,31 @@ export const D3Map: React.FC<D3MapProps> = ({
     function handlePointerEnter(event: PointerEvent) {
       if (event.pointerType !== "mouse") return;
       const [px, py] = d3.pointer(event, svgNode);
-      updateSelection(px, py, currentRadius);
+      updateSelection(px, py, s.currentRadius);
     }
 
     function handlePointerMove(event: PointerEvent) {
       if (event.pointerType !== "mouse") return;
       const [px, py] = d3.pointer(event, svgNode);
-      updateSelection(px, py, currentRadius);
+      updateSelection(px, py, s.currentRadius);
     }
 
     function handlePointerLeave(event: PointerEvent) {
       if (event.pointerType !== "mouse") return;
       ring.attr("cx", -9999).attr("cy", -9999);
-      currentCx = -9999;
-      currentCy = -9999;
-      onSelectionChange?.([]);
+      s.currentCx = -9999;
+      s.currentCy = -9999;
+      onSelectionChangeRef.current?.([]);
     }
 
     function handleWheel(event: WheelEvent) {
       event.preventDefault();
       const factor = event.deltaMode === 0 ? 0.002 : 0.06;
-      currentRadius = Math.max(10, Math.min(500, currentRadius * (1 - event.deltaY * factor)));
-      if (currentCx !== -9999) {
-        updateSelection(currentCx, currentCy, currentRadius);
+      s.currentRadius = Math.max(10, Math.min(500, s.currentRadius * (1 - event.deltaY * factor)));
+      if (s.currentCx !== -9999) {
+        updateSelection(s.currentCx, s.currentCy, s.currentRadius);
       } else {
-        ring.attr("r", currentRadius);
+        ring.attr("r", s.currentRadius);
       }
     }
 
@@ -1050,7 +1059,7 @@ export const D3Map: React.FC<D3MapProps> = ({
       svgNode.removeEventListener("pointerleave", handlePointerLeave);
       svgNode.removeEventListener("wheel", handleWheel);
     };
-  }, [mode, spotlightRadius, onSelectionChange, onSpotlightDebug, displayMask]);
+  }, [mode]); // callbacks + display state accessed via refs — no re-run needed when they change
 
   // --- Update colors on pointColors or palette change ---
   React.useEffect(() => {

--- a/src/components/convo-explorer/D3Map.tsx
+++ b/src/components/convo-explorer/D3Map.tsx
@@ -70,7 +70,7 @@ type D3MapProps = {
   /** When true, the spotlight circle stays in place after all fingers lift; the next touch moves it again (spotlight mode only) */
   spotlightPersist?: boolean;
   /** Debug callback fired on every spotlight touch/pointer event with internal state (spotlight mode only) */
-  onSpotlightDebug?: (state: { event: string; touchCount: number; primaryId: number | null; pinchRefDistance: number | null; pinchRefRadius: number | null; currentRadius: number }) => void;
+  onSpotlightDebug?: (state: { event: string; touchCount: number; currentRadius: number; cx: number; cy: number; grabOffsetX: number; grabOffsetY: number }) => void;
 };
 
 const PREFERRED_KEDRO_PIPELINE = 'mean_localmap_bestkmeans';
@@ -116,10 +116,12 @@ export const D3Map: React.FC<D3MapProps> = ({
     currentRadius: spotlightRadius,
     currentCx: -9999,
     currentCy: -9999,
-    primaryTouchId: null as number | null,
-    pinchRefDistance: null as number | null,
-    pinchRefRadius: null as number | null,
     persist: spotlightPersist,
+    // single-touch grab: offset from circle center to touch landing point
+    grabOffsetX: 0,
+    grabOffsetY: 0,
+    // two-touch transform: previous SVG positions keyed by touch identifier
+    touchPrevPositions: new Map<number, [number, number]>(),
   });
   // Keep callback refs so spotlight effect doesn't re-run when they change identity
   const onSelectionChangeRef = React.useRef(onSelectionChange);
@@ -884,20 +886,12 @@ export const D3Map: React.FC<D3MapProps> = ({
     const s = spotlightStateRef.current;
 
     function debug(eventName: string, touchCount: number) {
-      onSpotlightDebugRef.current?.({ event: eventName, touchCount, primaryId: s.primaryTouchId, pinchRefDistance: s.pinchRefDistance, pinchRefRadius: s.pinchRefRadius, currentRadius: s.currentRadius });
+      onSpotlightDebugRef.current?.({ event: eventName, touchCount, currentRadius: s.currentRadius, cx: s.currentCx, cy: s.currentCy, grabOffsetX: s.grabOffsetX, grabOffsetY: s.grabOffsetY });
     }
 
     function touchToSVG(touch: Touch): [number, number] {
       const rect = svgNode.getBoundingClientRect();
       return [touch.clientX - rect.left, touch.clientY - rect.top];
-    }
-
-    function findTouch(list: TouchList, id: number | null): Touch | null {
-      if (id === null) return null;
-      for (let i = 0; i < list.length; i++) {
-        if (list[i].identifier === id) return list[i];
-      }
-      return null;
     }
 
     function updateSelection(cx: number, cy: number, radius: number) {
@@ -914,30 +908,53 @@ export const D3Map: React.FC<D3MapProps> = ({
       onSelectionChangeRef.current?.(selected.map((d: any) => d.i));
     }
 
+    function resetAllTouches() {
+      s.touchPrevPositions.clear();
+      if (!s.persist) {
+        ring.attr("cx", -9999).attr("cy", -9999);
+        s.currentCx = -9999;
+        s.currentCy = -9999;
+        onSelectionChangeRef.current?.([]);
+      }
+    }
+
+    function captureAllTouches(touches: TouchList) {
+      s.touchPrevPositions.clear();
+      for (let i = 0; i < touches.length; i++) {
+        s.touchPrevPositions.set(touches[i].identifier, touchToSVG(touches[i]));
+      }
+    }
+
+    function setupGrabOffset(touch: Touch) {
+      const [tx, ty] = touchToSVG(touch);
+      s.grabOffsetX = s.currentCx === -9999 ? 0 : s.currentCx - tx;
+      s.grabOffsetY = s.currentCy === -9999 ? 0 : s.currentCy - ty;
+    }
+
     // --- Touch Events (handles multi-touch reliably via event.touches) ---
     function handleTouchStart(event: TouchEvent) {
       event.preventDefault();
       const n = event.touches.length;
+      captureAllTouches(event.touches);
 
       if (n === 1) {
-        s.primaryTouchId = event.touches[0].identifier;
-        s.pinchRefDistance = null;
-        s.pinchRefRadius = null;
-        const [px, py] = touchToSVG(event.touches[0]);
-        updateSelection(px, py, s.currentRadius);
-        debug("touch:start:1", n);
-      } else if (n === 2) {
-        const primary = findTouch(event.touches, s.primaryTouchId) ?? event.touches[0];
-        s.primaryTouchId = primary.identifier;
-        const secondary = [...event.touches].find(t => t.identifier !== s.primaryTouchId)!;
-        const [p1x, p1y] = touchToSVG(primary);
-        const [p2x, p2y] = touchToSVG(secondary);
-        const dx = p1x - p2x;
-        const dy = p1y - p2y;
-        s.pinchRefDistance = Math.max(1, Math.sqrt(dx * dx + dy * dy));
-        s.pinchRefRadius = s.currentRadius;
-        debug("touch:start:2", n);
+        const [tx, ty] = touchToSVG(event.touches[0]);
+        if (s.currentCx === -9999) {
+          // First placement — center circle on the touch point
+          updateSelection(tx, ty, s.currentRadius);
+          s.grabOffsetX = 0;
+          s.grabOffsetY = 0;
+        } else {
+          s.grabOffsetX = s.currentCx - tx;
+          s.grabOffsetY = s.currentCy - ty;
+        }
+      } else if (n === 2 && s.currentCx === -9999) {
+        // Two fingers on an unpositioned circle — place center at midpoint
+        const [ax, ay] = touchToSVG(event.touches[0]);
+        const [bx, by] = touchToSVG(event.touches[1]);
+        updateSelection((ax + bx) / 2, (ay + by) / 2, s.currentRadius);
       }
+      debug(`touch:start:${n}`, n);
     }
 
     function handleTouchMove(event: TouchEvent) {
@@ -945,22 +962,55 @@ export const D3Map: React.FC<D3MapProps> = ({
       const n = event.touches.length;
 
       if (n === 1) {
-        s.primaryTouchId = event.touches[0].identifier;
-        const [px, py] = touchToSVG(event.touches[0]);
-        updateSelection(px, py, s.currentRadius);
+        const touch = event.touches[0];
+        const [tx, ty] = touchToSVG(touch);
+        updateSelection(tx + s.grabOffsetX, ty + s.grabOffsetY, s.currentRadius);
+        s.touchPrevPositions.set(touch.identifier, [tx, ty]);
         debug("touch:move:1", n);
       } else if (n >= 2) {
-        const primary = findTouch(event.touches, s.primaryTouchId) ?? event.touches[0];
-        const secondary = [...event.touches].find(t => t.identifier !== primary.identifier);
-        if (!secondary || s.pinchRefDistance === null || s.pinchRefRadius === null) return;
+        const tA = event.touches[0];
+        const tB = event.touches[1];
+        const currA = touchToSVG(tA);
+        const currB = touchToSVG(tB);
+        const prevA = s.touchPrevPositions.get(tA.identifier);
+        const prevB = s.touchPrevPositions.get(tB.identifier);
 
-        const [p1x, p1y] = touchToSVG(primary);
-        const [p2x, p2y] = touchToSVG(secondary);
-        const dx = p1x - p2x;
-        const dy = p1y - p2y;
-        const dist = Math.sqrt(dx * dx + dy * dy);
-        s.currentRadius = Math.max(10, Math.min(500, s.pinchRefRadius * (dist / s.pinchRefDistance)));
-        updateSelection(p1x, p1y, s.currentRadius);
+        if (!prevA || !prevB) {
+          // Shouldn't normally happen — capture and wait for next frame
+          s.touchPrevPositions.set(tA.identifier, currA);
+          s.touchPrevPositions.set(tB.identifier, currB);
+          return;
+        }
+
+        const prevDist = Math.hypot(prevA[0] - prevB[0], prevA[1] - prevB[1]);
+        const currDist = Math.hypot(currA[0] - currB[0], currA[1] - currB[1]);
+        if (prevDist < 1) {
+          s.touchPrevPositions.set(tA.identifier, currA);
+          s.touchPrevPositions.set(tB.identifier, currB);
+          return;
+        }
+
+        const scale = currDist / prevDist;
+        const prevMidX = (prevA[0] + prevB[0]) / 2;
+        const prevMidY = (prevA[1] + prevB[1]) / 2;
+        const currMidX = (currA[0] + currB[0]) / 2;
+        const currMidY = (currA[1] + currB[1]) / 2;
+        const rotation = Math.atan2(currB[1] - currA[1], currB[0] - currA[0])
+                       - Math.atan2(prevB[1] - prevA[1], prevB[0] - prevA[0]);
+
+        // Apply similarity transform (scale + rotation + translation) to circle center
+        const dx = s.currentCx - prevMidX;
+        const dy = s.currentCy - prevMidY;
+        const cos = Math.cos(rotation);
+        const sin = Math.sin(rotation);
+        const newCx = currMidX + scale * (dx * cos - dy * sin);
+        const newCy = currMidY + scale * (dx * sin + dy * cos);
+
+        s.currentRadius = Math.max(10, Math.min(500, s.currentRadius * scale));
+        updateSelection(newCx, newCy, s.currentRadius);
+
+        s.touchPrevPositions.set(tA.identifier, currA);
+        s.touchPrevPositions.set(tB.identifier, currB);
         debug("touch:move:2", n);
       }
     }
@@ -968,23 +1018,12 @@ export const D3Map: React.FC<D3MapProps> = ({
     function handleTouchEnd(event: TouchEvent) {
       const n = event.touches.length;
       if (n === 0) {
-        s.primaryTouchId = null;
-        s.pinchRefDistance = null;
-        s.pinchRefRadius = null;
-        if (!s.persist) {
-          ring.attr("cx", -9999).attr("cy", -9999);
-          s.currentCx = -9999;
-          s.currentCy = -9999;
-          onSelectionChangeRef.current?.([]);
-        }
+        resetAllTouches();
         debug("touch:end:0", n);
-      } else if (n === 1) {
-        s.pinchRefDistance = null;
-        s.pinchRefRadius = null;
-        s.primaryTouchId = event.touches[0].identifier;
-        const [px, py] = touchToSVG(event.touches[0]);
-        updateSelection(px, py, s.currentRadius);
-        debug("touch:end:1", n);
+      } else {
+        captureAllTouches(event.touches);
+        if (n === 1) setupGrabOffset(event.touches[0]);
+        debug(`touch:end:${n}`, n);
       }
     }
 
@@ -992,15 +1031,10 @@ export const D3Map: React.FC<D3MapProps> = ({
       // Only reset if all touches are gone; spurious cancels mid-gesture should be ignored
       debug(`touch:cancel:${event.touches.length}`, event.touches.length);
       if (event.touches.length === 0) {
-        s.primaryTouchId = null;
-        s.pinchRefDistance = null;
-        s.pinchRefRadius = null;
-        if (!s.persist) {
-          ring.attr("cx", -9999).attr("cy", -9999);
-          s.currentCx = -9999;
-          s.currentCy = -9999;
-          onSelectionChangeRef.current?.([]);
-        }
+        resetAllTouches();
+      } else {
+        captureAllTouches(event.touches);
+        if (event.touches.length === 1) setupGrabOffset(event.touches[0]);
       }
     }
 

--- a/src/components/convo-explorer/D3Map.tsx
+++ b/src/components/convo-explorer/D3Map.tsx
@@ -947,18 +947,7 @@ export const D3Map: React.FC<D3MapProps> = ({
       } else if (n >= 2) {
         const primary = findTouch(event.touches, s.primaryTouchId) ?? event.touches[0];
         const secondary = [...event.touches].find(t => t.identifier !== primary.identifier);
-        if (!secondary) return;
-
-        if (s.pinchRefDistance === null || s.pinchRefRadius === null) {
-          const [p1x, p1y] = touchToSVG(primary);
-          const [p2x, p2y] = touchToSVG(secondary);
-          const dx = p1x - p2x;
-          const dy = p1y - p2y;
-          s.pinchRefDistance = Math.max(1, Math.sqrt(dx * dx + dy * dy));
-          s.pinchRefRadius = s.currentRadius;
-          debug("touch:move:2:ref", n);
-          return;
-        }
+        if (!secondary || s.pinchRefDistance === null || s.pinchRefRadius === null) return;
 
         const [p1x, p1y] = touchToSVG(primary);
         const [p2x, p2y] = touchToSVG(secondary);

--- a/src/components/convo-explorer/D3Map.tsx
+++ b/src/components/convo-explorer/D3Map.tsx
@@ -67,6 +67,8 @@ type D3MapProps = {
   displayMask?: boolean[];
   /** Color for unpainted points in groups mode. Defaults to UNPAINTED_COLOR (black). */
   unpaintedColor?: string;
+  /** When true, the spotlight circle stays in place after all fingers lift; the next touch moves it again (spotlight mode only) */
+  spotlightPersist?: boolean;
   /** Debug callback fired on every spotlight touch/pointer event with internal state (spotlight mode only) */
   onSpotlightDebug?: (state: { event: string; touchCount: number; primaryId: number | null; pinchRefDistance: number | null; pinchRefRadius: number | null; currentRadius: number }) => void;
 };
@@ -101,6 +103,7 @@ export const D3Map: React.FC<D3MapProps> = ({
   displayMask,
   unpaintedColor = UNPAINTED_COLOR,
   spotlightRadius = 60,
+  spotlightPersist = false,
   onSpotlightDebug,
 }) => {
   const svgRef = React.useRef<SVGSVGElement>(null);
@@ -116,6 +119,7 @@ export const D3Map: React.FC<D3MapProps> = ({
     primaryTouchId: null as number | null,
     pinchRefDistance: null as number | null,
     pinchRefRadius: null as number | null,
+    persist: spotlightPersist,
   });
   // Keep callback refs so spotlight effect doesn't re-run when they change identity
   const onSelectionChangeRef = React.useRef(onSelectionChange);
@@ -124,8 +128,9 @@ export const D3Map: React.FC<D3MapProps> = ({
   React.useEffect(() => { onSelectionChangeRef.current = onSelectionChange; }, [onSelectionChange]);
   React.useEffect(() => { onSpotlightDebugRef.current = onSpotlightDebug; }, [onSpotlightDebug]);
   React.useEffect(() => { displayMaskRef.current = displayMask; }, [displayMask]);
-  // Sync slider value into state ref without re-running the spotlight effect
+  // Sync prop values into state ref without re-running the spotlight effect
   React.useEffect(() => { spotlightStateRef.current.currentRadius = spotlightRadius; }, [spotlightRadius]);
+  React.useEffect(() => { spotlightStateRef.current.persist = spotlightPersist; }, [spotlightPersist]);
   const lassoStateRef = React.useRef<{
     path: d3.Selection<SVGPathElement, unknown, null, undefined> | null;
     coords: [number, number][];
@@ -963,13 +968,15 @@ export const D3Map: React.FC<D3MapProps> = ({
     function handleTouchEnd(event: TouchEvent) {
       const n = event.touches.length;
       if (n === 0) {
-        ring.attr("cx", -9999).attr("cy", -9999);
-        s.currentCx = -9999;
-        s.currentCy = -9999;
         s.primaryTouchId = null;
         s.pinchRefDistance = null;
         s.pinchRefRadius = null;
-        onSelectionChangeRef.current?.([]);
+        if (!s.persist) {
+          ring.attr("cx", -9999).attr("cy", -9999);
+          s.currentCx = -9999;
+          s.currentCy = -9999;
+          onSelectionChangeRef.current?.([]);
+        }
         debug("touch:end:0", n);
       } else if (n === 1) {
         s.pinchRefDistance = null;
@@ -985,13 +992,15 @@ export const D3Map: React.FC<D3MapProps> = ({
       // Only reset if all touches are gone; spurious cancels mid-gesture should be ignored
       debug(`touch:cancel:${event.touches.length}`, event.touches.length);
       if (event.touches.length === 0) {
-        ring.attr("cx", -9999).attr("cy", -9999);
-        s.currentCx = -9999;
-        s.currentCy = -9999;
         s.primaryTouchId = null;
         s.pinchRefDistance = null;
         s.pinchRefRadius = null;
-        onSelectionChangeRef.current?.([]);
+        if (!s.persist) {
+          ring.attr("cx", -9999).attr("cy", -9999);
+          s.currentCx = -9999;
+          s.currentCy = -9999;
+          onSelectionChangeRef.current?.([]);
+        }
       }
     }
 

--- a/src/components/convo-explorer/D3Map.tsx
+++ b/src/components/convo-explorer/D3Map.tsx
@@ -69,6 +69,9 @@ type D3MapProps = {
   unpaintedColor?: string;
   /** When true, the spotlight circle stays in place after all fingers lift; the next touch moves it again (spotlight mode only) */
   spotlightPersist?: boolean;
+  /** Called whenever the spotlight radius changes internally (wheel or pinch), so the parent can sync a slider.
+   *  Primarily useful for Storybook/debug UIs — likely not needed in the app itself. */
+  onSpotlightRadiusChange?: (radius: number) => void;
   /** Debug callback fired on every spotlight touch/pointer event with internal state (spotlight mode only) */
   onSpotlightDebug?: (state: { event: string; touchCount: number; currentRadius: number; cx: number; cy: number; grabOffsetX: number; grabOffsetY: number }) => void;
 };
@@ -104,6 +107,7 @@ export const D3Map: React.FC<D3MapProps> = ({
   unpaintedColor = UNPAINTED_COLOR,
   spotlightRadius = 60,
   spotlightPersist = false,
+  onSpotlightRadiusChange,
   onSpotlightDebug,
 }) => {
   const svgRef = React.useRef<SVGSVGElement>(null);
@@ -126,12 +130,20 @@ export const D3Map: React.FC<D3MapProps> = ({
   // Keep callback refs so spotlight effect doesn't re-run when they change identity
   const onSelectionChangeRef = React.useRef(onSelectionChange);
   const onSpotlightDebugRef = React.useRef(onSpotlightDebug);
+  const onSpotlightRadiusChangeRef = React.useRef(onSpotlightRadiusChange);
   const displayMaskRef = React.useRef(displayMask);
   React.useEffect(() => { onSelectionChangeRef.current = onSelectionChange; }, [onSelectionChange]);
   React.useEffect(() => { onSpotlightDebugRef.current = onSpotlightDebug; }, [onSpotlightDebug]);
+  React.useEffect(() => { onSpotlightRadiusChangeRef.current = onSpotlightRadiusChange; }, [onSpotlightRadiusChange]);
   React.useEffect(() => { displayMaskRef.current = displayMask; }, [displayMask]);
+  // Tracks whether the most recent spotlightRadius change was reported outward by a gesture.
+  // If so, the sync effect must not write back — doing so would overwrite a newer gesture value.
+  const radiusFromGestureRef = React.useRef(false);
   // Sync prop values into state ref without re-running the spotlight effect
-  React.useEffect(() => { spotlightStateRef.current.currentRadius = spotlightRadius; }, [spotlightRadius]);
+  React.useEffect(() => {
+    if (radiusFromGestureRef.current) { radiusFromGestureRef.current = false; return; }
+    spotlightStateRef.current.currentRadius = spotlightRadius;
+  }, [spotlightRadius]);
   React.useEffect(() => { spotlightStateRef.current.persist = spotlightPersist; }, [spotlightPersist]);
   const lassoStateRef = React.useRef<{
     path: d3.Selection<SVGPathElement, unknown, null, undefined> | null;
@@ -1008,6 +1020,8 @@ export const D3Map: React.FC<D3MapProps> = ({
 
         s.currentRadius = Math.max(10, Math.min(500, s.currentRadius * scale));
         updateSelection(newCx, newCy, s.currentRadius);
+        radiusFromGestureRef.current = true;
+        onSpotlightRadiusChangeRef.current?.(s.currentRadius);
 
         s.touchPrevPositions.set(tA.identifier, currA);
         s.touchPrevPositions.set(tB.identifier, currB);
@@ -1068,6 +1082,8 @@ export const D3Map: React.FC<D3MapProps> = ({
       } else {
         ring.attr("r", s.currentRadius);
       }
+      radiusFromGestureRef.current = true;
+      onSpotlightRadiusChangeRef.current?.(s.currentRadius);
     }
 
     svgNode.addEventListener("touchstart", handleTouchStart, { passive: false });


### PR DESCRIPTION
## Summary

- Adds a `mode="spotlight"` to `D3Map`: a dashed circle follows the cursor and continuously selects all points within its radius — no lasso drag needed
- **Desktop**: ring follows mouse; scroll wheel resizes it
- **Touch**: single finger grabs the circle by its contact point (offset-preserving translation); two fingers apply an incremental similarity transform each frame — scale, rotation, and translation all work symmetrically, like placing a sticker
- `spotlightRadius` prop sets the initial radius (default 60px); `spotlightPersist` prop keeps the circle frozen in place after all fingers lift so the next touch resumes from there
- New `SpotlightModeSelection` Storybook story with live debug panel (current state, event log, copy/clear), radius slider that tracks pinch/wheel resizing, and persist toggle
- `onSpotlightRadiusChange` callback (annotated as story/debug infrastructure) lets the parent sync a slider display without jitter — solved via a `radiusFromGestureRef` flag that breaks the prop↔ref feedback loop

## Key implementation notes

- All mutable touch state lives in `spotlightStateRef` (a `useRef`) so it survives effect re-runs; callbacks accessed via refs so they never appear in deps
- Two-touch transform uses per-frame deltas (`touchPrevPositions` map) rather than a fixed reference, giving smooth sticker-like behaviour regardless of where fingers land
- Zoom/pan is blocked in spotlight mode via the D3 zoom filter

## Test plan

- [ ] Desktop: hover over map — ring follows cursor, selection updates live; scroll wheel resizes ring
- [ ] Desktop: ring stays visible when mouse is still (not just on move)
- [ ] Touch (Android): single finger drags circle without snapping center to touch point
- [ ] Touch: two-finger pinch resizes, rotate rotates center around midpoint, translate moves freely
- [ ] Touch: `spotlightPersist` checkbox — circle stays put after lifting fingers, resumes on next touch
- [ ] Radius slider tracks pinch/wheel resizing without jitter; slider still sets radius when no gesture active
- [ ] Map zoom/pan does not occur in spotlight mode
- [ ] `pnpm run build` passes TypeScript checks

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~250 words of PR description from ~350 words of human prompts across this session)